### PR TITLE
fixed memory calculation for align process

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -80,7 +80,7 @@ workflow ATAC_CHIP {
         // calculate total memory required for align+sort:
         m1 = params.align_mem.replaceAll(".GB|GB|G", "").toInteger()
         m2 = params.sort_mem.replaceAll(".GB|GB|G", "").toInteger() * params.sort_threads
-        total_mem = (m1+m2)  
+        total_mem = "${(m1+m2)}.GB"
 
         if(params.trim_adapter == ''){
             if(params.atacseq){


### PR DESCRIPTION
Fix total memory requirement for the align process. Currently (and this needs to be fixed to a more elaborate solution in the future) the process takes two memory params, being `--align_mem` and `--sort_mem` for alignment with bowtie2 and sort with samtools. The first must be in standard nextflow syntax, e.g. '8.GB'  and the second one in `samtools sort` syntax, e.g. `1G`. Currently only integers are allowed, and only in Gigabytes so the naive summing https://github.com/ATpoint/atac_chip_preprocess/compare/dev?expand=1#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28R83 can work. Needs a more elaborate solution that takes K/M/G and also floats.