### PR TITLE
fix parsing of peak calling args and fix order of chromsizes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,8 +31,7 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
 
-      # Test via docker
-      - name: TEST-DOCKER
+      - name: TEST-DOCKER-ATACseq
         run: |
           NXF_VER=21.10.6 nextflow run main.nf -profile test,docker --keep_merge --keep_trim
           
@@ -50,3 +49,7 @@ jobs:
             git commit -am "current software versions and command lines"
             git push          
           fi
+
+      - name: TEST-DOCKER-ChIPseq
+        run: |
+          NXF_VER=21.10.6 nextflow run main.nf -profile test,docker --keep_merge --keep_trim --atacseq false --macs_additional '\--keep-dup=all --nomodel --extsize 150'

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ We used reasonable defaults for all processing steps that should be used without
 - `--align_additional`: additional arguments for the `bowtie2` alignment process beyond what is coded in the module definition, default is `-X2000 --very-sensitive`, see `bowtie2` [manual](https://bowtie-bio.sourceforge.net/bowtie2/manual.shtml)
 - `--sort_additional`: additional arguments for the `samtools` sorting process beyond what is coded in the module definition, default is `-l 6` to compress the resulting BAM file to that level  
 - `--filter_additional`: additional arguments for the `samtools view` filtering process beyond what is described above and given with the `-q` and `-F` flags
-- `--macs_additional`: additional arguments for the `macs2 callpeak`, default is in any case `--keep-dup=all` since we provide already deduplicated data to that process and if ATAC-seq data are processed (default) then `--nomodel --extsize 100 --shift -50 --min-length 250` to provide some smoothing when using the cutsites for peak calling.  
+- `--macs_additional`: additional arguments for the `macs2 callpeak`, default is in any case `--keep-dup=all` since we provide already deduplicated data to that process and if ATAC-seq data are processed (default) then `--nomodel --extsize 100 --shift -50 --min-length 250` to provide some smoothing when using the cutsites for peak calling.
 
 ## Resources
 

--- a/main.nf
+++ b/main.nf
@@ -275,11 +275,10 @@ workflow {
     // that depend on the chromsizes output
     ch_for_chromsizes = Align.out.tuple_bam
                         .map { [it[1].getName(), it[1]] }
-                        .toSortedList()
-                        .flatMap()
-                        .first()
-                        .map {it[1]}
-
+                        .toSortedList( { a, b -> b[1] <=> a[1] } )
+                        .map{it[0]}
+                        .map{it[1]}
+                        
     Chromsizes(ch_for_chromsizes)
     chromsizes_versions = Chromsizes.out.versions
     

--- a/main.nf
+++ b/main.nf
@@ -269,9 +269,20 @@ workflow {
     // Chromsizes
     // ----------------------------------------------------------------------------------------
 
-    Chromsizes(Align.out.tuple_bam.first())
-    chromsizes_versions = Chromsizes.out.versions
+    // This sort makes the channel order deterministic as channel order itself is unsorted/random
+    // and hence a simple first() would result in different files to fetch chromsizes from so
+    // a -resume would still cause rerun of that process and as such all downstream processes
+    // that depend on the chromsizes output
+    ch_for_chromsizes = Align.out.tuple_bam
+                        .map { [it[1].getName(), it[1]] }
+                        .toSortedList()
+                        .flatMap()
+                        .first()
+                        .map {it[1]}
 
+    Chromsizes(ch_for_chromsizes)
+    chromsizes_versions = Chromsizes.out.versions
+    
     // ----------------------------------------------------------------------------------------
     // Filtering of alignments
     // ----------------------------------------------------------------------------------------

--- a/main.nf
+++ b/main.nf
@@ -53,31 +53,62 @@ evaluate(new File("${baseDir}/functions/validate_schema_params.nf"))
 
 include{ ValidateSamplesheet } from './modules/validatesamplesheet'
 
+//------------------------------------------------------------------------
+
 include{ CatFastq } from './modules/cat_fastq' addParams(outdir: params.merge_dir, keep: params.keep_merge)
+
+//------------------------------------------------------------------------
 
 include{ Fastqc } from './modules/fastqc' addParams(outdir: params.fastqc_dir)
 
+//------------------------------------------------------------------------
+
 include{ Trim } from './modules/trim' addParams(outdir: params.trim_dir, args: params.trim_additional, keep: params.keep_merge)
+
+//------------------------------------------------------------------------
 
 include{ Align } from './modules/align' addParams(outdir: params.align_dir, args: params.align_additional, args2: params.sort_additional)
 
+//------------------------------------------------------------------------
+
 include{ Chromsizes } from './modules/chromsizes' addParams(outdir: params.misc_dir)
+
+//------------------------------------------------------------------------
 
 include{ Filter } from './modules/filter' addParams(outdir: params.filter_dir, args: params.filter_additional)
 
+//------------------------------------------------------------------------
+
 include{ Isizes } from './modules/isizes' addParams(outdir: params.misc_dir)
+
+//------------------------------------------------------------------------
 
 include{ Cutsites } from './modules/cutsites' addParams(outdir: params.bed_dir)
 
-include{ Peaks } from './modules/peaks' addParams(outdir: params.peaks_dir, args: params.macs_additional)
+//------------------------------------------------------------------------
+
+// If ATAC-seq => set default, if not ATAC-seq => set different defaults, or overwrite completely if the user uses --macs_additional
+args_peaks = params.macs_additional=='' ? (params.atacseq ? '--keep-dup=all --nomodel --extsize 100 --shift -50 --min-length 250' : '--keep-dup=all') : params.macs_additional
+
+include{ Peaks } from './modules/peaks' addParams(outdir: params.peaks_dir, args: args_peaks)
+
+//------------------------------------------------------------------------
 
 include{ Frips } from './modules/frips' addParams(outdir: params.frip_dir)
 
+//------------------------------------------------------------------------
+
 include{ FripsCollect } from './modules/frips' addParams(outdir: params.frip_dir)
+
+//------------------------------------------------------------------------
 
 include{ Bigwigs } from './modules/bigwigs' addParams(outdir: params.bigwig_dir)
 
+//------------------------------------------------------------------------
+
 include{ Multiqc } from './modules/multiqc' addParams(outdir: params.multiqc_dir)
+
+//------------------------------------------------------------------------
 
 include{ CommandLines } from './modules/commandline' addParams(outdir: params.pipeline_dir)                                                              
 

--- a/misc/command_lines.txt
+++ b/misc/command_lines.txt
@@ -25,8 +25,8 @@ Bigwigs:sample3
 CatFastq:sample1	
 	cat 1/sample1_1.fastq.gz 2/sample1_1.fastq.gz > sample1_merged_R1.fq.gz
 	cat 3/sample1_2.fastq.gz 4/sample1_2.fastq.gz > sample1_merged_R2.fq.gz
-Chromsizes:sample2	
-	samtools view -H sample2_raw.bam | grep ^@SQ | cut -f2,3 | awk 'OFS=\t {gsub(SN:|LN:,);print}' | sort -k1,1 > chromsizes.txt
+Chromsizes:	
+	samtools view -H sample1_raw.bam | grep ^@SQ | cut -f2,3 | awk 'OFS=\t {gsub(SN:|LN:,);print}' | sort -k1,1 > chromsizes.txt
 Cutsites:sample1	
 	bedtools bamtobed -i sample1_filtered.bam | mawk 'OFS=	 {if ($6 == +) print $1, $2+4, $2+5, ., ., $6} {if ($6 == -) print $1, $3-5, $3-4, ., ., $6}' | sort -k1,1 -k2,2n -k3,3n -k6,6 -S 2G --parallel=1 > sample1_cutsites.bed
 	bgzip -l 6 -@ 1 sample1_cutsites.bed
@@ -79,17 +79,17 @@ Multiqc:
 	multiqc .
 Peaks:sample1	
 	export OPENBLAS_NUM_THREADS=1 # should keep blas library from unwanted multithreading
-	macs2 callpeak --nomodel --extsize 150 --keep-dup=all --nomodel --extsize 100 --shift -50 --min-length 250 --tempdir ./ -f BED -g mm -t sample1_cutsites.bed.gz -n sample1_all
+	macs2 callpeak --keep-dup=all --nomodel --extsize 100 --shift -50 --min-length 250 --tempdir ./ -f BED -g mm -t sample1_cutsites.bed.gz -n sample1_all
 	bedtools intersect -v -a sample1_all_peaks.narrowPeak -b mm10_combined_blacklist.bed > sample1_peaks.narrowPeak
 	bedtools intersect -v -a sample1_all_summits.bed -b mm10_combined_blacklist.bed > sample1_peaks.bed
 Peaks:sample2	
 	export OPENBLAS_NUM_THREADS=1 # should keep blas library from unwanted multithreading
-	macs2 callpeak --nomodel --extsize 150 --keep-dup=all --nomodel --extsize 100 --shift -50 --min-length 250 --tempdir ./ -f BED -g mm -t sample2_cutsites.bed.gz -n sample2_all
+	macs2 callpeak --keep-dup=all --nomodel --extsize 100 --shift -50 --min-length 250 --tempdir ./ -f BED -g mm -t sample2_cutsites.bed.gz -n sample2_all
 	bedtools intersect -v -a sample2_all_peaks.narrowPeak -b mm10_combined_blacklist.bed > sample2_peaks.narrowPeak
 	bedtools intersect -v -a sample2_all_summits.bed -b mm10_combined_blacklist.bed > sample2_peaks.bed
 Peaks:sample3	
 	export OPENBLAS_NUM_THREADS=1 # should keep blas library from unwanted multithreading
-	macs2 callpeak --nomodel --extsize 150 --keep-dup=all --nomodel --extsize 100 --shift -50 --min-length 250 --tempdir ./ -f BED -g mm -t sample3_cutsites.bed.gz -n sample3_all
+	macs2 callpeak --keep-dup=all --nomodel --extsize 100 --shift -50 --min-length 250 --tempdir ./ -f BED -g mm -t sample3_cutsites.bed.gz -n sample3_all
 	bedtools intersect -v -a sample3_all_peaks.narrowPeak -b mm10_combined_blacklist.bed > sample3_peaks.narrowPeak
 	bedtools intersect -v -a sample3_all_summits.bed -b mm10_combined_blacklist.bed > sample3_peaks.bed
 Trim:sample1	

--- a/modules/chromsizes.nf
+++ b/modules/chromsizes.nf
@@ -16,7 +16,7 @@ process Chromsizes {
     container params.container
 
     input:
-    tuple val(meta), path(bam), path(bai)
+    path(bam)
 
     output:
     path("chromsizes.txt"), emit: chromsizes
@@ -27,7 +27,7 @@ process Chromsizes {
     """
     samtools view -H $bam | grep "^@SQ" | cut -f2,3 | awk 'OFS="\\t" {gsub("SN:|LN:","");print}' | sort -k1,1 > chromsizes.txt
 
-    echo ${task.process}:${meta.id} > command_lines.txt
+    echo ${task.process}: > command_lines.txt
     cat .command.sh | grep -vE '^#!/bin|versions.txt\$|command_lines.txt\$|cat \\.command.sh' | sed 's/  */ /g' | awk NF >> command_lines.txt
 
     echo 'awk:' \$(awk -W version 2>&1 | head -n 1 | cut -d " " -f2,3 | tr " " "-") > versions.txt

--- a/modules/peaks.nf
+++ b/modules/peaks.nf
@@ -27,15 +27,13 @@ process Peaks {
     script:
 
     if(params.atacseq){ format = 'BED' } else { format = meta.single_end ? 'BAM' : 'BAMPE' }
-    def species = params.species
-    def args2 = params.atacseq ? '--nomodel --extsize 100 --shift -50 --min-length 250' : ' '
-    
+        
     if(params.filter_blacklist){
         
         """
         export OPENBLAS_NUM_THREADS=1 # should keep blas library from unwanted multithreading
 
-        macs2 callpeak $params.args $args2 --tempdir ./ -f $format -g $species -t $data -n ${meta.id}_all
+        macs2 callpeak $params.args --tempdir ./ -f $format -g $params.species -t $data -n ${meta.id}_all
 
         bedtools intersect -v -a ${meta.id}_all_peaks.narrowPeak -b $blacklist > ${meta.id}_peaks.narrowPeak
         bedtools intersect -v -a ${meta.id}_all_summits.bed -b $blacklist > ${meta.id}_peaks.bed
@@ -52,7 +50,7 @@ process Peaks {
         """
         export OPENBLAS_NUM_THREADS=1 # should keep blas library from unwanted multithreading
 
-        macs2 callpeak $params.args $args2 --tempdir ./ -f $format -g $species -t $data -n ${meta.id}
+        macs2 callpeak $params.args --tempdir ./ -f $format -g $params.species -t $data -n ${meta.id}
 
         echo ${task.process}:${meta.id} > command_lines.txt
         cat .command.sh | grep -vE '^#!/bin|versions.txt\$|command_lines.txt\$|cat \\.command.sh' | sed 's/  */ /g' | awk NF >> command_lines.txt

--- a/nextflow.config
+++ b/nextflow.config
@@ -115,7 +115,6 @@ profiles {
 
         params.samplesheet      = "$baseDir/test/samplesheet.csv"
         params.index            = "$baseDir/test/example_index"
-        params.macs_additional  = '--nomodel --extsize 150 --keep-dup=all' // otherwise CI test chokes on the small test dataset
 
         }
 

--- a/schema.nf
+++ b/schema.nf
@@ -58,7 +58,7 @@ schema.filter_additional = [value: '', type: 'string']
 
 // Peak calling, FRiPs and Bigwigs
 schema.title6           = [title: 'PEAK CALLING / QC OPTIONS']
-schema.macs_additional  = [value: '--keep-dup=all', type: 'string']
+schema.macs_additional  = [value: '', type: 'string']
 schema.filter_blacklist = [value: true, type: 'logical']
 schema.fragment_length  = [value: 250, type: 'numeric']
 


### PR DESCRIPTION
- fix the parsing of the peak calling custom arguments, moved from the module to the main script
- made sure that now the input for the chromsizes process is now deterministic, previously it was random which bam file was used, hence a `-resume` did rerun downstream processes depending on which file was used before.